### PR TITLE
Fix Incompatibility to Setuptools Version 78.0.0+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+long_description = file: README.rst
 license_file = LICENSE
 
 [bdist_wheel]


### PR DESCRIPTION
---

Setuptools no longer accepts options containing dash characters in setup.cfg (see https://setuptools.pypa.io/en/stable/history.html).