### PR TITLE
Do not discard code at address 0x0 (fixes #6042)

### DIFF
--- a/src/fpvgcc/gccMemoryMap.py
+++ b/src/fpvgcc/gccMemoryMap.py
@@ -217,8 +217,6 @@ class GCCMemoryMapNode(SizeNTreeNode):
             return 'DISCARDED'
         if self._address is None:
             return 'UNDEF'
-        if self._address == 0:
-            return "DISCARDED"
         for region in self.tree.memory_regions:
             if self._address in region:
                 if region.name in ctx.suppressed_regions:

--- a/src/fpvgcc/profiles/__init__.py
+++ b/src/fpvgcc/profiles/__init__.py
@@ -1,12 +1,14 @@
 
 
 from .context import ContextBase
+from .arm_gnu_toolchain import ProfileArmGnuToolchain
 from .gcc_msp430 import ProfileGccMsp430
 
 
 def _load_profiles():
     return {
         'default': ContextBase,
+        ProfileArmGnuToolchain.id: ProfileArmGnuToolchain,
         ProfileGccMsp430.id: ProfileGccMsp430,
     }
 

--- a/src/fpvgcc/profiles/arm_gnu_toolchain.py
+++ b/src/fpvgcc/profiles/arm_gnu_toolchain.py
@@ -1,0 +1,34 @@
+from .context import ContextBase
+
+class ProfileArmGnuToolchain(ContextBase):
+    id = 'arm-gnu-toolchain'
+
+    def __init__(self):
+        super(ProfileArmGnuToolchain, self).__init__()
+        self._suppressed_names.extend([
+                'attributes',
+                'comment',
+                'debug',
+                'debug_abbrev',
+                'debug_aranges',
+                'debug_frame',
+                'debug_funcnames',
+                'debug_info',
+                'debug_line',
+                'debug_line_str',
+                'debug_loc',
+                'debug_loclists',
+                'debug_macinfo',
+                'debug_macro',
+                'debug_pubnames',
+                'debug_pubtypes',
+                'debug_ranges',
+                'debug_rnglists',
+                'debug_sfnames',
+                'debug_srcinfo',
+                'debug_str',
+                'debug_typenames',
+                'debug_varnames',
+                'debug_weaknames',
+                'line',
+        ])


### PR DESCRIPTION
Address 0x0 is a legitimate location on some embedded targets e.g. Microchip SAM L21 flash starts at 0x0, hence the vector table is located there.