### PR TITLE
Do not discard code at address zero (closes #13)

### DIFF
--- a/src/fpvgcc/gccMemoryMap.py
+++ b/src/fpvgcc/gccMemoryMap.py
@@ -217,8 +217,6 @@ class GCCMemoryMapNode(SizeNTreeNode):
             return 'DISCARDED'
         if self._address is None:
             return 'UNDEF'
-        if self._address == 0:
-            return "DISCARDED"
         for region in self.tree.memory_regions:
             if self._address in region:
                 if region.name in ctx.suppressed_regions:

--- a/src/fpvgcc/profiles/context.py
+++ b/src/fpvgcc/profiles/context.py
@@ -3,7 +3,21 @@
 class ContextBase(object):
 
     def __init__(self):
-        self._suppressed_names = []
+        self._suppressed_names = [
+            'attributes',
+            'comment',
+            'debug_abbrev',
+            'debug_aranges',
+            'debug_frame',
+            'debug_info',
+            'debug_line',
+            'debug_line_str',
+            'debug_loc',
+            'debug_loclists',
+            'debug_ranges',
+            'debug_rnglists',
+            'debug_str',
+        ]
         self._suppressed_regions = ['*default*']
 
     @property

--- a/src/fpvgcc/profiles/gcc_msp430.py
+++ b/src/fpvgcc/profiles/gcc_msp430.py
@@ -7,15 +7,4 @@ class ProfileGccMsp430(ContextBase):
 
     def __init__(self):
         super(ProfileGccMsp430, self).__init__()
-        self._suppressed_names.extend([
-                'debug_line',
-                'debug_info',
-                'debug_ranges',
-                'debug_aranges',
-                'debug_loc',
-                'debug_str',
-                'debug_frame',
-                'debug_abbrev',
-                'comment',
-                'MSP430'
-        ])
+        self._suppressed_names.extend(['MSP430'])


### PR DESCRIPTION
Address zero is a legitimate location on some embedded targets e.g. Microchip SAM L21 flash starts at 0x00000000, hence the vector table is located there.